### PR TITLE
Update to 1.0.0 and implement analyzer test infrastructure

### DIFF
--- a/src/CodeFormatter/CodeFormatter.csproj
+++ b/src/CodeFormatter/CodeFormatter.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CodeFormatter</RootNamespace>
     <AssemblyName>CodeFormatter</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,33 +33,24 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable">
       <Private>true</Private>
-      <HintPath>..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel">
@@ -79,7 +70,7 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/CodeFormatter/packages.config
+++ b/src/CodeFormatter/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/AnalyzerTestBase.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/AnalyzerTestBase.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using System.Threading;
+
+namespace Microsoft.DotNet.CodeFormatting.Tests
+{
+    public abstract class AnalyzerTestBase : CodeFormattingTestBase
+    {
+        private IFormattingEngine _engine;
+
+        protected AnalyzerTestBase(IFormattingEngine engine)
+        {
+            _engine = engine;
+        }
+
+        protected override async Task<Solution> Format(Solution solution, bool runFormatter)
+        {
+            Workspace workspace = solution.Workspace;
+            await _engine.FormatSolutionAsync(solution, default(CancellationToken)).ConfigureAwait(false);
+            return workspace.CurrentSolution;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
                 document = await RewriteDocumentAsync(document);
                 if (runFormatter)
                 {
-                    document = await Formatter.FormatAsync(document);
+                    document = await Formatter.FormatAsync(document).ConfigureAwait(false);
                 }
 
                 solution = document.Project.Solution;

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/CodeFormattingTestBase.cs
@@ -17,9 +17,9 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
 {
     public abstract class CodeFormattingTestBase
     {
-        private static readonly MetadataReference s_CorlibReference = MetadataReference.CreateFromAssembly(typeof(object).Assembly);
-        private static readonly MetadataReference s_SystemCoreReference = MetadataReference.CreateFromAssembly(typeof(Enumerable).Assembly);
-        private static readonly MetadataReference s_CodeFormatterReference = MetadataReference.CreateFromAssembly(typeof(IFormattingEngine).Assembly);
+        private static readonly MetadataReference s_CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        private static readonly MetadataReference s_SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        private static readonly MetadataReference s_CodeFormatterReference = MetadataReference.CreateFromFile(typeof(IFormattingEngine).Assembly.Location);
 
         private const string FileNamePrefix = "Test";
         private const string CSharpFileExtension = ".cs";
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             string fileExtension = language == LanguageNames.CSharp ? CSharpFileExtension : VBFileExtension;
             var projectId = ProjectId.CreateNewId(TestProjectName);
 
-            var solution = new CustomWorkspace()
+            var solution = new AdhocWorkspace()
                 .CurrentSolution
                 .AddProject(projectId, TestProjectName, TestProjectName, language)
                 .AddMetadataReferences(projectId, GetSolutionMetadataReferences());

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DotNet.CodeFormatting.Tests</RootNamespace>
     <AssemblyName>Microsoft.DotNet.CodeFormatting.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -34,46 +34,31 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -92,7 +77,7 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Microsoft.DotNet.CodeFormatting.Tests.csproj
@@ -104,6 +104,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AnalyzerTestBase.cs" />
     <Compile Include="CodeFormattingTestBase.cs" />
     <Compile Include="Rules\BracesRuleTests.cs" />
     <Compile Include="Rules\CombinationTest.cs" />

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Xunit;
+﻿using Xunit;
 using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.CodeFormatting.Tests
@@ -13,7 +6,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
     /// <summary>
     /// A test which runs all rules on a given piece of code 
     /// </summary>
-    public sealed class CombinationTest : RuleTestBase
+    public sealed class CombinationTest : AnalyzerTestBase
     {
         private static FormattingEngineImplementation s_formattingEngine;
 
@@ -22,41 +15,11 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
             s_formattingEngine = (FormattingEngineImplementation)FormattingEngine.Create(ImmutableArray<string>.Empty);
         }
 
-        public CombinationTest()
+        public CombinationTest() : base(s_formattingEngine)
         {
             s_formattingEngine.CopyrightHeader = ImmutableArray.Create("", "// header");
             s_formattingEngine.FormatLogger = new EmptyFormatLogger();
             s_formattingEngine.PreprocessorConfigurations = ImmutableArray<string[]>.Empty;
-        }
-
-        // The tests in this class cannot yet be implemented.
-        //
-        // The test in all the other test classes exercise individual rules.
-        // They derive from one of the three classes SyntaxRuleTestBase,
-        // LocalSemanticRuleTestBase, or GlobalSemanticRuleTestBase, each of
-        // which overrides RewriteDocumentAsync to run a single rule on a
-        // document.
-        //
-        // But the tests in this class want to run all the rules, so this class
-        // overrides RewriteDocumentAsync to call FormattingEngineImplementation.
-        // FormatCoreAsync, which runs all the rules on a specified set of files
-        // in a specified solution. But Sri's version of FormattingEngineImplementation
-        // doesn't have a method FormatCoreAsync.
-        //
-        // For now, we comment out the body of RewriteDocumentAsync to allow
-        // the test project to build, and mark all tests in this class as skipped
-        // so we have a green bar going foward. We also comment out the "async"
-        // keyword to be able to build warning-free.
-        protected override /* async */ Task<Document> RewriteDocumentAsync(Document document)
-        {
-#if NOT_YET_IMPLEMENTED
-            var solution = await s_formattingEngine.FormatCoreAsync(
-                document.Project.Solution,
-                new[] { document.Id },
-                CancellationToken.None);
-            return solution.GetDocument(document.Id);
-#endif
-            return null;
         }
 
         [Fact(Skip = "NYI")]

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/CombinationTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.CodeFormatting.Tests
     /// <summary>
     /// A test which runs all rules on a given piece of code 
     /// </summary>
-    public sealed class CombinationTest : CodeFormattingTestBase
+    public sealed class CombinationTest : RuleTestBase
     {
         private static FormattingEngineImplementation s_formattingEngine;
 

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/ExplicitThisRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/ExplicitThisRuleTests.cs
@@ -123,7 +123,7 @@ class C1
 
     void M()
     {
-        _field /* comment 2 */ = 0;
+         /* comment1 */ _field /* comment 2 */ = 0;
         // before comment
         _field = 42;
         // after comment

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/UsesXunitForTestsFormattingRuleTests.cs
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/Rules/UsesXunitForTestsFormattingRuleTests.cs
@@ -194,8 +194,8 @@ namespace System.Composition.UnitTests
             Verify(text, expected);
         }
 
-        private static readonly MetadataReference s_MSTestReference = MetadataReference.CreateFromAssembly(typeof(VisualStudio.TestTools.UnitTesting.TestMethodAttribute).Assembly);
-        private static readonly MetadataReference s_XunitReference = MetadataReference.CreateFromAssembly(typeof(FactAttribute).Assembly);
+        private static readonly MetadataReference s_MSTestReference = MetadataReference.CreateFromFile(typeof(VisualStudio.TestTools.UnitTesting.TestMethodAttribute).Assembly.Location);
+        private static readonly MetadataReference s_XunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
 
         protected override IEnumerable<MetadataReference> GetSolutionMetadataReferences()
         {

--- a/src/Microsoft.DotNet.CodeFormatting.Tests/packages.config
+++ b/src/Microsoft.DotNet.CodeFormatting.Tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />

--- a/src/Microsoft.DotNet.CodeFormatting/Analyzers/ExplicitThisAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Analyzers/ExplicitThisAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.CodeFormatting.Analyzers
                 if (node != null)
                 {
                     if (node.Expression != null &&
-                        node.Expression.CSharpKind() == SyntaxKind.ThisExpression &&
+                        node.Expression.Kind() == SyntaxKind.ThisExpression &&
                         IsPrivateField(node, syntaxContext.SemanticModel, syntaxContext.CancellationToken))
                     {
                         syntaxContext.ReportDiagnostic(Diagnostic.Create(rule, node.GetLocation()));

--- a/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
+++ b/src/Microsoft.DotNet.CodeFormatting/Microsoft.DotNet.CodeFormatting.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DotNet.CodeFormatting</RootNamespace>
     <AssemblyName>Microsoft.DotNet.CodeFormatting</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -31,33 +31,24 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Collections.Immutable">
       <Private>true</Private>
-      <HintPath>..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel">
@@ -77,7 +68,7 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/BraceNewLineRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/BraceNewLineRule.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             var tokensToReplace = syntaxNode.DescendantTokens().Where((token) =>
                 {
                     var nextToken = token.GetNextToken();
-                    if (token.CSharpKind() != SyntaxKind.OpenBraceToken || !nextToken.HasLeadingTrivia)
+                    if (token.Kind() != SyntaxKind.OpenBraceToken || !nextToken.HasLeadingTrivia)
                     {
                         return false;
                     }
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 return token;
             }
 
-            if (token.CSharpKind() == SyntaxKind.CloseBraceToken && 
+            if (token.Kind() == SyntaxKind.CloseBraceToken && 
                 token.LeadingTrivia.All(x => x.IsKind(SyntaxKind.WhitespaceTrivia) || x.IsKind(SyntaxKind.EndOfLineTrivia)))
             {
                 // This is an open / close brace combo with no content inbetween.  Just return the 
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             var tokensToReplace = syntaxNode.DescendantTokens().Where((token) => 
                 {
                     return
-                        token.CSharpKind() == SyntaxKind.CloseBraceToken &&
+                        token.Kind() == SyntaxKind.CloseBraceToken &&
                         token.HasLeadingTrivia &&
                         (IsSimpleNewLine(token.LeadingTrivia, 0) || IsSimpleNewLine(token.LeadingTrivia, token.LeadingTrivia.Count - 1));
                 });
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             while (index >= 0 && searching)
             {
                 var current = triviaList[index];
-                switch (current.CSharpKind())
+                switch (current.Kind())
                 {
                     case SyntaxKind.WhitespaceTrivia:
                     case SyntaxKind.EndOfLineTrivia:
@@ -218,12 +218,12 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 return NewLineKind.None;
             }
 
-            switch (list[index].CSharpKind())
+            switch (list[index].Kind())
             {
                 case SyntaxKind.EndOfLineTrivia:
                     return NewLineKind.NewLine;
                 case SyntaxKind.WhitespaceTrivia:
-                    if (index + 1 < list.Count && list[index + 1].CSharpKind() == SyntaxKind.EndOfLineTrivia)
+                    if (index + 1 < list.Count && list[index + 1].Kind() == SyntaxKind.EndOfLineTrivia)
                     {
                         return NewLineKind.WhitespaceAndNewLine;
                     }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitThisRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitThisRule.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 node = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node);
                 var name = node.Name.Identifier.ValueText;
                 if (node.Expression != null &&
-                    node.Expression.CSharpKind() == SyntaxKind.ThisExpression &&
+                    node.Expression.Kind() == SyntaxKind.ThisExpression &&
                     IsPrivateField(node))
                 {
                     _addedAnnotations = true;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
             {
-                if (node.Modifiers.Any(x => x.CSharpKind() == SyntaxKind.StaticKeyword))
+                if (node.Modifiers.Any(x => x.Kind() == SyntaxKind.StaticKeyword))
                 {
                     return node;
                 }
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             private SyntaxKind GetTypeDefaultVisibility(BaseTypeDeclarationSyntax originalDeclarationSyntax)
             {
                 // In the case of partial types we need to use the existing visibility if it exists
-                if (originalDeclarationSyntax.Modifiers.Any(x => x.CSharpContextualKind() == SyntaxKind.PartialKeyword))
+                if (originalDeclarationSyntax.Modifiers.Any(x => x.Kind() == SyntaxKind.PartialKeyword))
                 {
                     SyntaxKind? kind = GetExistingPartialVisibility(originalDeclarationSyntax);
                     if (kind.HasValue)
@@ -160,9 +160,9 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             {
                 foreach (var token in list)
                 {
-                    if (SyntaxFacts.IsAccessibilityModifier(token.CSharpKind()))
+                    if (SyntaxFacts.IsAccessibilityModifier(token.Kind()))
                     {
-                        return token.CSharpKind();
+                        return token.Kind();
                     }
                 }
 
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 var current = node.Parent;
                 while (current != null)
                 {
-                    if (SyntaxFacts.IsTypeDeclaration(current.CSharpKind()))
+                    if (SyntaxFacts.IsTypeDeclaration(current.Kind()))
                     {
                         return true;
                     }
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             /// </summary>
             private static MemberDeclarationSyntax EnsureVisibility<T>(T node, SyntaxTokenList originalModifiers, Func<T, SyntaxTokenList, T> withModifiers, Func<SyntaxKind> getDefaultVisibility) where T : MemberDeclarationSyntax
             {
-                if (originalModifiers.Any(x => SyntaxFacts.IsAccessibilityModifier(x.CSharpKind())))
+                if (originalModifiers.Any(x => SyntaxFacts.IsAccessibilityModifier(x.Kind())))
                 {
                     return node;
                 }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/FormatDocumentFormattingRule.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,9 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
@@ -38,7 +35,6 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 {
                     var list = new List<string>(configuration.Length + 1);
                     list.AddRange(configuration);
-                    list.Add(FormattingEngineImplementation.TablePreprocessorSymbolName);
 
                     var newParseOptions = parseOptions.WithPreprocessorSymbols(list);
                     document = project.WithParseOptions(newParseOptions).GetDocument(document.Id);

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasCopyrightHeaderFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasCopyrightHeaderFormattingRule.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
         private bool HasCopyrightHeader(SyntaxNode syntaxNode)
         {
-            var leadingComments = syntaxNode.GetLeadingTrivia().Where(t => t.CSharpKind() == SyntaxKind.SingleLineCommentTrivia).ToArray();
+            var leadingComments = syntaxNode.GetLeadingTrivia().Where(t => t.Kind() == SyntaxKind.SingleLineCommentTrivia).ToArray();
             var header = _options.CopyrightHeader;
             if (leadingComments.Length < header.Length)
                 return false;

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNewLineBeforeFirstNamespaceFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNewLineBeforeFirstNamespaceFormattingRule.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             if (firstNamespace.HasLeadingTrivia)
             {
                 var trivia = firstNamespace.GetLeadingTrivia();
-                if (SyntaxKind.EndOfLineTrivia == trivia.Last().CSharpKind())
+                if (SyntaxKind.EndOfLineTrivia == trivia.Last().Kind())
                 {
                     newTrivia = GetLeadingTriviaWithEndNewLines(trivia);
                 }
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             int index = trivia.Count() - 2;
             while (index >= 0)
             {
-                if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).CSharpKind())
+                if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).Kind())
                     break;
                 index--;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             int index = trivia.Count() - 1;
             while (index >= 0 &&
                 (trivia.ElementAt(index).HasStructure ||
-                trivia.ElementAt(index).CSharpKind() == SyntaxKind.DisabledTextTrivia))
+                trivia.ElementAt(index).Kind() == SyntaxKind.DisabledTextTrivia))
                 index--;
 
             if (index < 0)
@@ -92,11 +92,11 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             }
 
             // Add two new lines (previous element is a comment) before the structure trivia list.
-            if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).CSharpKind())
+            if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).Kind())
                 return trivia.Take(index + 1).AddTwoNewLines().Concat(trivia.Skip(index + 1));
 
             // Insert one new line before the structured trivia, previous element is new line
-            if (index != 0 && SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index - 1).CSharpKind())
+            if (index != 0 && SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index - 1).Kind())
                 return trivia.Take(index + 1).AddNewLine().Concat(trivia.Skip(index + 1));
 
             // Already has the right format

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNewLineBeforeFirstUsingFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNewLineBeforeFirstUsingFormattingRule.cs
@@ -31,15 +31,15 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             if (firstUsing.HasLeadingTrivia)
             {
                 var trivia = firstUsing.GetLeadingTrivia();
-                var x = trivia.FirstOrDefault(t => t.CSharpKind() == SyntaxKind.DisabledTextTrivia && t.ToFullString().Contains("using"));
-                var disabledUsingSpan = trivia.FirstOrDefault(t => t.CSharpKind() == SyntaxKind.DisabledTextTrivia && t.ToFullString().Contains("using")).Span;
+                var x = trivia.FirstOrDefault(t => t.Kind() == SyntaxKind.DisabledTextTrivia && t.ToFullString().Contains("using"));
+                var disabledUsingSpan = trivia.FirstOrDefault(t => t.Kind() == SyntaxKind.DisabledTextTrivia && t.ToFullString().Contains("using")).Span;
                 if (!disabledUsingSpan.IsEmpty)
                 {
                     Console.WriteLine("!!!Error with using");
                     return syntaxRoot;
                 }
 
-                if (SyntaxKind.EndOfLineTrivia == trivia.Last().CSharpKind())
+                if (SyntaxKind.EndOfLineTrivia == trivia.Last().Kind())
                 {
                     newTrivia = GetLeadingTriviaWithEndNewLines(trivia);
                 }
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             int index = trivia.Count() - 2;
             while (index >= 0)
             {
-                if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).CSharpKind())
+                if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).Kind())
                     break;
                 index--;
             }
@@ -96,11 +96,11 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             }
 
             // Insert two new lines before the structured trivia, previous element is a comment
-            if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).CSharpKind())
+            if (SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index).Kind())
                 return trivia.Take(index + 1).AddTwoNewLines().Concat(trivia.Skip(index + 1));
 
             // Insert one new line before the structured trivia, previous element is new line
-            if (index != 0 && SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index - 1).CSharpKind())
+            if (index != 0 && SyntaxKind.EndOfLineTrivia != trivia.ElementAt(index - 1).Kind())
                 return trivia.Take(index + 1).AddNewLine().Concat(trivia.Skip(index + 1));
 
             // Already has the right format

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoCustomCopyrightHeaderFormattingRule.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             var trivia = currentTrivia.Token.LeadingTrivia;
             return trivia.SkipWhile(t => t != currentTrivia)
                          .Skip(1)
-                         .SkipWhile(t => t.CSharpKind() != SyntaxKind.SingleLineCommentTrivia)
+                         .SkipWhile(t => t.Kind() != SyntaxKind.SingleLineCommentTrivia)
                          .Select(t => (SyntaxTrivia?)t)
                          .FirstOrDefault();
         }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/HasNoIllegalHeadersFormattingRule.cs
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
             newTrivia = newTrivia.RemoveAt(index);
 
             // Remove end of line after trivia
-            if (index < newTrivia.Count && newTrivia.ElementAt(index).CSharpKind() == SyntaxKind.EndOfLineTrivia)
+            if (index < newTrivia.Count && newTrivia.ElementAt(index).Kind() == SyntaxKind.EndOfLineTrivia)
             {
                 newTrivia = newTrivia.RemoveAt(index);
             }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NonAsciiCharactersAreEscapedInLiteralsRule.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             public override SyntaxNode VisitLiteralExpression(LiteralExpressionSyntax node)
             {
-                switch (node.CSharpKind())
+                switch (node.Kind())
                 {
                     case SyntaxKind.StringLiteralExpression:
                         return RewriteStringLiteralExpression(node);
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             private static SyntaxNode RewriteStringLiteralExpression(LiteralExpressionSyntax node)
             {
-                Debug.Assert(node.CSharpKind() == SyntaxKind.StringLiteralExpression);
+                Debug.Assert(node.Kind() == SyntaxKind.StringLiteralExpression);
 
                 if (node.Token.IsVerbatimStringLiteral())
                 {
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
 
             private static SyntaxNode RewriteCharacterLiteralExpression(LiteralExpressionSyntax node)
             {
-                Debug.Assert(node.CSharpKind() == SyntaxKind.CharacterLiteralExpression);
+                Debug.Assert(node.Kind() == SyntaxKind.CharacterLiteralExpression);
 
                 if (HasNonAsciiCharacters(node.Token.Text))
                 {

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
                 isInstance = true;
                 foreach (var modifier in fieldSyntax.Modifiers)
                 {
-                    switch (modifier.CSharpKind())
+                    switch (modifier.Kind())
                     {
                         case SyntaxKind.PublicKeyword:
                         case SyntaxKind.ConstKeyword:

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/UsesXunitForTestsFormattingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/UsesXunitForTestsFormattingRule.cs
@@ -254,11 +254,11 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
         {
             foreach (var trivia in stl)
             {
-                if (trivia.CSharpKind() == SyntaxKind.IfDirectiveTrivia ||
-                    trivia.CSharpKind() == SyntaxKind.DisabledTextTrivia ||
-                    trivia.CSharpKind() == SyntaxKind.EndIfDirectiveTrivia ||
-                    trivia.CSharpKind() == SyntaxKind.ElifDirectiveTrivia ||
-                    trivia.CSharpKind() == SyntaxKind.ElseDirectiveTrivia)
+                if (trivia.Kind() == SyntaxKind.IfDirectiveTrivia ||
+                    trivia.Kind() == SyntaxKind.DisabledTextTrivia ||
+                    trivia.Kind() == SyntaxKind.EndIfDirectiveTrivia ||
+                    trivia.Kind() == SyntaxKind.ElifDirectiveTrivia ||
+                    trivia.Kind() == SyntaxKind.ElseDirectiveTrivia)
                 {
                     stl = stl.Remove(trivia);
                 }

--- a/src/Microsoft.DotNet.CodeFormatting/packages.config
+++ b/src/Microsoft.DotNet.CodeFormatting/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />


### PR DESCRIPTION
This PR has two parts:

1. Update Roslyn NuGet dependencies to 1.0.0, update project files to match, and modify sources to account for changes in the Roslyn APIs since Beta.

2. Modify the unit test infrastructure to enable testing formatters that are implemented as "analyzers" as well as "rules". Instead of deriving SyntaxRuleTestBase, LocalSemanticRuleTestBase, and GlobalSemanticRuleTestBase directly from CodeFormatterTestBase, we introduce an intermediate base class RuleTestBase, which derives from CodeFormatterTestBase, and from which those three classes derive. All rule-based formatters will use this derivation tree and require no changes.

We then introduce AnalyzerTestBase, derived from CodeFormatterTestBase, and from which all analyzer-based tests will derive.

Ultimately all the "rules" will be gone, replaced by analyzers. At that time we'll remove all the rule-centric test classes, and we can, if we like, merge AnalyzerTestBase back down into CodeFormatterTestBase.

With this commit, the unit tests all pass, and the command line program works.